### PR TITLE
Multipart support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.3 - October 1, 2015
+
+* Added support for multipart request (POST and PUT)
+
 ## v1.4.2 - November 17, 2014
 
 * Updated the readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.4.3 - October 1, 2015
+## v1.5.0 - October 1, 2015
 
 * Added support for multipart request (POST and PUT)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.lotaris.api</groupId>
   <artifactId>java-api-test</artifactId>
-  <version>1.4.2</version>
+  <version>1.4.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Lotaris API Test Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -195,10 +195,17 @@
 	</profiles>
 
   <dependencies>
-		<!-- Jersey client dependencies -->
+	  
+		<!-- Apache client dependencies -->
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
+			<version>4.3.3</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpmime</artifactId>
 			<version>4.3.3</version>
 		</dependency>
 

--- a/src/main/java/com/lotaris/api/test/AbstractApiTest.java
+++ b/src/main/java/com/lotaris/api/test/AbstractApiTest.java
@@ -4,6 +4,7 @@ import com.lotaris.api.test.rules.ApiTestClientRule;
 import com.lotaris.api.test.rules.ApiTestHeaderConfigurationRule;
 import com.jayway.jsonassert.JsonAssert;
 import com.jayway.jsonassert.JsonAsserter;
+import com.lotaris.api.test.client.ApiTestMultipartFormData;
 import com.lotaris.api.test.client.ApiTestFormUrlEncoded;
 import com.lotaris.api.test.rules.ApiTestHeadersManagerRule;
 import com.lotaris.api.test.client.ApiTestRequest;
@@ -249,6 +250,17 @@ public abstract class AbstractApiTest {
 	protected ApiTestResponse postResource(ApiTestFormUrlEncoded body, ApiUriBuilder urlBuilder) {
 		return executeStandardRequest(ApiTestRequest.POST, urlBuilder, body);
 	}
+	
+	/**
+	 * Performs a POST request on a resource.
+	 *
+	 * @param body the request body
+	 * @param urlBuilder URI builder
+	 * @return the API response
+	 */
+	protected ApiTestResponse postResource(ApiTestMultipartFormData body, ApiUriBuilder urlBuilder) {
+		return executeStandardRequest(ApiTestRequest.POST, urlBuilder, body);
+	}
 
 	/**
 	 * Performs a PUT request on a resource.
@@ -280,6 +292,17 @@ public abstract class AbstractApiTest {
 	 * @return the API response
 	 */
 	protected ApiTestResponse putResource(ApiTestFormUrlEncoded body, ApiUriBuilder uriBuilder) {
+		return executeStandardRequest(ApiTestRequest.PUT, uriBuilder, body);
+	}
+	
+	/**
+	 * Performs a PUT request on a resource.
+	 *
+	 * @param body the request body
+	 * @param uriBuilder URI builder
+	 * @return the API response
+	 */
+	protected ApiTestResponse putResource(ApiTestMultipartFormData body, ApiUriBuilder uriBuilder) {
 		return executeStandardRequest(ApiTestRequest.PUT, uriBuilder, body);
 	}
 
@@ -559,6 +582,27 @@ public abstract class AbstractApiTest {
 	 * @return the API response
 	 */
 	private ApiTestResponse executeStandardRequest(String method, ApiUriBuilder uriBuilder, ApiTestFormUrlEncoded data) {
+		return executeStandardRequest(method, uriBuilder, data != null ? ApiTestRequestBody.from(data) : null);
+	}
+	
+	/**
+	 * Executes an API request that has a multipart form data body and expects a JSON response. By
+	 * default:
+	 *
+	 * <ul>
+	 * <li>the <tt>Accept</tt> header is set to <tt>application/json</tt>;</li>
+	 * <li>if provided, the form URL-encoded data is used as the request body and the
+	 * <tt>Content-Type</tt>
+	 * header is set to <tt>multipart/form-data</tt>;</li>
+	 * <li>request headers are configured by the headers manager rule.</li>
+	 * </ul>
+	 *
+	 * @param method the HTTP method
+	 * @param uriBuilder the URI builder
+	 * @param data optional name/value pairs to use as request body
+	 * @return the API response
+	 */
+	private ApiTestResponse executeStandardRequest(String method, ApiUriBuilder uriBuilder, ApiTestMultipartFormData data) {
 		return executeStandardRequest(method, uriBuilder, data != null ? ApiTestRequestBody.from(data) : null);
 	}
 

--- a/src/main/java/com/lotaris/api/test/client/ApiTestMultipartFormData.java
+++ b/src/main/java/com/lotaris/api/test/client/ApiTestMultipartFormData.java
@@ -1,0 +1,52 @@
+package com.lotaris.api.test.client;
+
+import java.io.File;
+import java.io.InputStream;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+
+/**
+ * Container to send form data
+ *
+ * @author Valentin Delaye <valentin.delaye@novaccess.ch>
+ */
+public class ApiTestMultipartFormData {
+	
+	private MultipartEntityBuilder builder;
+
+	public ApiTestMultipartFormData() {
+		builder = MultipartEntityBuilder.create();
+	}
+	
+	public ApiTestMultipartFormData addData(String key, byte[] array) {
+		builder.addBinaryBody(key, array);
+		return this;
+	}
+	
+	public ApiTestMultipartFormData addData(String key, File file) {
+		builder.addBinaryBody(key, file);
+		return this;
+	}
+	
+	public ApiTestMultipartFormData addData(String key, InputStream stream) {
+		builder.addBinaryBody(key, stream);
+		return this;
+	}
+	
+	public ApiTestMultipartFormData addData(String key, String value, String contentType) {
+		builder.addTextBody(key, value, ContentType.create(contentType));
+		return this;
+	}
+	
+	public ApiTestMultipartFormData addData(String key, String value) {
+		builder.addTextBody(key, value);
+		return this;
+	}
+	
+	public HttpEntity getMultipartEntity() {
+		return builder.build();
+	}
+	
+	
+}

--- a/src/main/java/com/lotaris/api/test/client/ApiTestRequestBody.java
+++ b/src/main/java/com/lotaris/api/test/client/ApiTestRequestBody.java
@@ -11,6 +11,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 
 /**
  * HTTP request body wrapper.
@@ -65,6 +66,18 @@ public class ApiTestRequestBody {
 		final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(data.getPairs(), StandardCharsets.UTF_8);
 		return new ApiTestRequestBody(entity);
 	}
+	
+	/**
+	 * Constructs a request body with content type <tt>multipart/form-data</tt> from
+	 * a multi part entity.
+	 *
+	 * @param data The multi part form data
+	 * @return an API request body
+	 */
+	public static ApiTestRequestBody from(ApiTestMultipartFormData data) {
+		return new ApiTestRequestBody(data.getMultipartEntity());
+	}
+	
 	//</editor-fold>
 	/**
 	 * The request body.


### PR DESCRIPTION
Add multipart request support for POST and PUT (ex : uploading a file on the API).
- Added apache http mime dependency

Usage 

```
ApiTestMultipartFormData data = new ApiTestMultipartFormData();
data.addData("file", myByteArrayOrFileOrStream);
data.addData("property", "A string property");
ApiTestResponse response = postResource(data, uri("api/uploadImage"));
```

Tested and retro-compatible with 1.4.2

Please release as soon as possible. Thanks.
